### PR TITLE
Add Twilio integration for sending SMS #3

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -30,3 +30,4 @@ ongoworks:security
 alanning:roles
 service-configuration
 raix:push
+accolver:twilio-meteor

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,3 +1,4 @@
+accolver:twilio-meteor@1.10.1
 accounts-base@1.1.3
 accounts-facebook@1.0.3
 accounts-google@1.0.3

--- a/server/notfications.js
+++ b/server/notfications.js
@@ -31,6 +31,26 @@ Meteor.methods({
       default:
         return false;
     }
+  },
+  sendSMSNotification: function (toPhoneNum, smsMessage) {
+    /* need to add the account details of twilio */
+    var AccountSID = '';
+    var AuthToken = '';
+    var fromMobileNumber = '+13202458411';
+
+    twilio = Twilio(AccountSID, AuthToken);
+    twilio.sendSms({
+      to:toPhoneNum, // Any number Twilio can deliver to
+      from: fromMobileNumber, // A number you bought from Twilio and can use for outbound communication
+      body: smsMessage // body of the SMS message
+    }, function(err, responseData) { //this function is executed when a response is received from Twilio
+      if (!err) {
+        console.log(responseData.from);
+        console.log(responseData.body);
+      } else {
+        console.log(err);
+      }
+    });
   }
 });
 


### PR DESCRIPTION
Added the Meteor server function to send SMS notification. It will take the phone number to send sms to and the message for the sms.
This will need the Twilioi tokens to work.
